### PR TITLE
fix: handling error response from one of the providers.

### DIFF
--- a/src/fiat/ars.rs
+++ b/src/fiat/ars.rs
@@ -33,7 +33,7 @@ async fn get_calypso_price(asset: &str) -> Result<f64, Error> {
 // return only one
 pub async fn get_ars_price() -> f64 {
     let binance_price_ars: f64 = get_binance_mean_p2p_price("USDT", "ARS").await;
-    let calypso_price_ars: f64 = get_calypso_price("USDT").await.unwrap();
+    let calypso_price_ars: f64 = get_calypso_price("USDT").await.unwrap_or(0f64);
     let price_source_a = PriceSource {
         price: binance_price_ars,
         fiat: String::from("ARS"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,10 +92,10 @@ async fn main() {
             .unwrap() as u64,
     );
     let gas_amount = Coin {
-        amount: 250_000u128,
+        amount: 320u128,
         denom: "ukuji".parse().unwrap(),
     };
-    let auth_info = signer_info.auth_info(Fee::from_amount_and_gas(gas_amount, 1_000_000u64));
+    let auth_info = signer_info.auth_info(Fee::from_amount_and_gas(gas_amount, 250_000u64));
     let tx_body = tx_body_builder.finish();
     let account_number = account_data
         .account

--- a/src/shared.rs
+++ b/src/shared.rs
@@ -36,8 +36,10 @@ impl From<&ReqwestError> for Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        // TODO: write different msgs for different error types
-        write!(f, "Error TODO")
+        match self.kind {
+            ErrorKind::Request => write!(f, "Request error"),
+            ErrorKind::Response => write!(f, "Response error"),
+        }
     }
 }
 


### PR DESCRIPTION
Task: LOCAL-979

Changes: 
- Handling when Calypso Price is Zero or API call fails
- Fix: overpaying fees
- Bettor error formatting.

How to test:
`cargo run`